### PR TITLE
Add check for getBundle() before usage

### DIFF
--- a/og.module
+++ b/og.module
@@ -2605,6 +2605,9 @@ function og_is_member($group_type, $gid, $entity_type = 'user', $entity = NULL, 
  */
 function og_is_group_default_access($group_type, $gid) {
   $wrapper = entity_metadata_wrapper($group_type, $gid);
+  if (!is_callable(array($wrapper, 'getBundle'))) {
+    return false;
+  }
   $bundle = $wrapper->getBundle();
 
   if (!field_info_instance($group_type, OG_DEFAULT_ACCESS_FIELD, $bundle)) {


### PR DESCRIPTION
In some cases, getBundle() could be called when getBundle() didn't exist on the wrapper. This resulted in a fatal PHP error. This makes a check for getBundle() before it's called.

Drupal: https://www.drupal.org/project/og/issues/2998637